### PR TITLE
Changes in ubuntuhostsetup.sh and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ git clone https://github.com/itsmaverick/ngp-vagrant
 
 Add your Gateway IP 
 ------------------------
-Add your gateway IP address, look for <changeme> in provision/ubuntuhostsetup.sh
+Add your gateway IP address. The default gateway is router created by VirtualBox for VMs:
+```sh
+sudo ip route add default via 10.0.2.2
+```
+Change this ip if required in provision/ubuntuhostsetup.sh
 
 
 Create Virtual BOX instances
@@ -93,10 +97,13 @@ Deploy the CP on all hosts
 run the cloud command to deploy CP on all hosts
 cgroup is the folder in which cgroup is installed on the hosts, mostly it is /cgroup or /sys/fs/cgroup
 ```sh
-cloud/cloud -log dc create -cgroup=/sys/fs/cgroup -space 192.0.0.0/12 -network 192.2.0.0/16 
-cloud/cloud -log dc attach -cgroup=/sys/fs/cgroup  <HOST1 IP>
-cloud/cloud -log dc attach -cgroup=/sys/fs/cgroup  <HOST2 IP>
-cloud/cloud -log dc attach -cgroup=/sys/fs/cgroup  <HOST3 IP>
+cloud/cloud --log [string] dc create --space 192.0.0.0/12 -network 192.2.0.0/16 
+cloud/cloud --log [string] dc attach <HOST1 IP> <HOST2 IP> <HOST3 IP>
+```
+
+For EPAM developers: you should change the first command due to conflict with EPAM network
+```sh
+cloud/cloud --log [string] dc create --space 192.168.0.0/16 --network 192.168.0.0/12 
 ```
 
 Test Consul

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ run the cloud command to deploy CP on all hosts
 cgroup is the folder in which cgroup is installed on the hosts, mostly it is /cgroup or /sys/fs/cgroup
 ```sh
 cloud/cloud --log [string] dc create --space 192.0.0.0/12 -network 192.2.0.0/16 
-cloud/cloud --log [string] dc attach <HOST1 IP> <HOST2 IP> <HOST3 IP>
+cloud/cloud --log [string] dc -u [username] -p [password] attach <HOST1 IP> <HOST2 IP> <HOST3 IP>
 ```
+NOTE that you need a credentials to run "cloud dc attach" command.
 
 For EPAM developers: you should change the first command due to conflict with EPAM network
 ```sh

--- a/provision/ubuntuhostsetup.sh
+++ b/provision/ubuntuhostsetup.sh
@@ -37,7 +37,8 @@ sudo cp -rf /vagrant/docker.cfg /etc/default/docker
 sudo usermod -aG docker vagrant
 sudo service docker restart
 echo "Configuring /etc/hosts"
-new_ip=$(ip address show eth1 | grep 'inet ' | sed -e 's/^.*inet //' -e 's/\/.*$//')
+# CP uses eth0 interface, so new_ip should be taken from eth0
+new_ip=$(ip address show eth0 | grep 'inet ' | sed -e 's/^.*inet //' -e 's/\/.*$//')
 name=$(hostname)
 echo "$new_ip $name $name" 
 sed "10 c\

--- a/provision/ubuntuhostsetup.sh
+++ b/provision/ubuntuhostsetup.sh
@@ -7,6 +7,9 @@ sudo ip link set dev eth0 down && ip link set eth0 name eth00 && ip link set dev
 sudo ip link set dev eth1 down && ip link set eth1 name eth0 && ip link set dev eth0 up
 sudo ip link set dev eth00 down && ip link set eth00 name eth1 && ip link set dev eth1 up
 
+# We need to turn off ipv6 due to issues with it in VMs
+sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+
 echo "Provisioning virtual machine..."
 #echo "adding gateway..."
 #sudo route del -net 0.0.0.0 

--- a/provision/ubuntuhostsetup.sh
+++ b/provision/ubuntuhostsetup.sh
@@ -41,9 +41,13 @@ echo "Configuring /etc/hosts"
 new_ip=$(ip address show eth0 | grep 'inet ' | sed -e 's/^.*inet //' -e 's/\/.*$//')
 name=$(hostname)
 echo "$new_ip $name $name" 
-sed "10 c\
-$new_ip $name $name" /etc/hosts > a
+# It's better to change /etc/hosts in the following manner instead of previous one
+echo "$new_ip $name $name
+127.0.0.1 localhost">a
 sudo mv a /etc/hosts
+#sed "10 c\
+#$new_ip $name $name" /etc/hosts > a
+#sudo mv a /etc/hosts
 
 # Git
 #echo "Installing Git"

--- a/provision/ubuntuhostsetup.sh
+++ b/provision/ubuntuhostsetup.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# We need to rename some interfaces due to conflict between vagrant and CP (vagrant
+# creates NAT interface for access Internet through eth0 and CP is trying to use
+# eth0 for connection between nodes)
+sudo ip link set dev eth0 down && ip link set eth0 name eth00 && ip link set dev eth00 up
+sudo ip link set dev eth1 down && ip link set eth1 name eth0 && ip link set dev eth0 up
+sudo ip link set dev eth00 down && ip link set eth00 name eth1 && ip link set dev eth1 up
+
 echo "Provisioning virtual machine..."
 #echo "adding gateway..."
 #sudo route del -net 0.0.0.0 

--- a/provision/ubuntuhostsetup.sh
+++ b/provision/ubuntuhostsetup.sh
@@ -15,6 +15,8 @@ echo "Provisioning virtual machine..."
 #sudo route del -net 0.0.0.0 
 # santa clara your gw is 10.32.0.1, canada:172.31.1.1 add your gateway ip here
 #sudo route add -net 0.0.0.0 gw 10.32.0.1  dev eth1
+# 10.0.2.2 - router created by VirtualBox for VMs. You should check this.
+sudo ip route add default via 10.0.2.2
 
 echo "Installing Docker"
 sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D

--- a/provision/ubuntuhostsetup.sh
+++ b/provision/ubuntuhostsetup.sh
@@ -24,8 +24,11 @@ sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58
 # Ubuntu Trusty 
 sudo echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list
 
+# This command is actual for Belarus. Please comment it if you are going to use original repo
+sudo sed -i 's/archive.ubuntu.com/by.archive.ubuntu.com/g' /etc/apt/sources.list
 sudo apt-get update
-sudo apt-get install docker-engine=1.9.1-0~trusty -y > /dev/null
+# We need to install docker-engine v.1.13.1-0~ubuntu-trusty instead of previos 1.9.1-0~trusty
+sudo apt-get install docker-engine=1.13.1-0~ubuntu-trusty -y > /dev/null
 
 
 sudo groupadd docker


### PR DESCRIPTION
Hi Sadasivudu,

I tried to follow all steps in "NGP Orchestration using vagrant and virtualbox" but I wasn't managed to deploy cluster. So to deploy cluster using vagrant and VirtualBox I made some changes in ubuntuhostsetup.sh script (I added comments for all changes inside this file) and made minor changes in README.md file to correct some steps (e.g. adding of gateway and deploying CP on all hosts, it seems that cloud command format and options was changed after Jun 23, 2016). According to my changes the cluster can be deployed again.